### PR TITLE
(maint) Create CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Setting ownership to the tooling team
-* @puppetlabs/tooling
+* @puppetlabs/devx


### PR DESCRIPTION
Prior to this commit the CODEOWNERS file did not exist. We use this file to help contributors find the people who work on the code.