### PR TITLE
(CAT-2281) Remove puppet 7 infrastructure

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.154.2/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 2, 2.7, 2.6, 2.5
-ARG VARIANT="2.7"
+ARG VARIANT="3.1"
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-${VARIANT}
 
 # [Option] Install Node.js

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "args": {
       // Update 'VARIANT' to pick a Ruby version: 2, 2.7, 2.6, 2.5
-      "VARIANT": "2.5",
+      "VARIANT": "3.1",
       // Options
       "INSTALL_NODE": "false",
       "NODE_VERSION": "lts/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.7'
           - '3.2'
         include:
-          - ruby_version: '2.7'
-            puppet_version: '~> 7.0'
           - ruby_version: '3.2'
             puppet_version: '~> 8.0'
         runs-on: 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,11 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.7'
           - '3.2'
         include:
-          - ruby_version: '2.7'
-            puppet_version: '~> 7.0'
           - ruby_version: '3.2'
             puppet_version: '~> 8.0'
         runs-on: 


### PR DESCRIPTION
Puppet 7 is EOL. Therefore, we can remove the test infrastructure for it. This commit aims to clear up any testing/config infrastructure related to Puppet 7 and, by extension, Ruby 2.7.